### PR TITLE
Unhide save and export buttons

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -191,6 +191,45 @@ h1 {
   }
 }
 
+/* Sticky action bar positioning above the tab bar */
+.sticky-actions {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: calc(var(--tabbar-height) + var(--safe-bottom));
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  padding: 10px 12px;
+  background: #ffffff;
+  border-top: 1px solid #e5e5e7;
+  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.06);
+  z-index: 1100;
+}
+
+/* Ensure page content leaves room for sticky actions on mobile */
+body.has-sticky-actions.safe-padding-bottom {
+  padding-bottom: calc(
+    max(0.75rem, var(--safe-bottom)) +
+    var(--tabbar-height) +
+    72px
+  );
+}
+
+/* Inline actions visible on larger screens; hidden when sticky bar is present */
+.inline-actions {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .inline-actions {
+    display: grid;
+  }
+  .sticky-actions {
+    display: none;
+  }
+}
+
 /* form layout - vertical stack with consistent spacing */
 form {
   display: flex;

--- a/www/index.html
+++ b/www/index.html
@@ -19,7 +19,7 @@
     <link rel="apple-touch-icon" href="assets/mount-builder.png" />
     <link rel="icon" type="image/png" href="assets/mount-builder.png" />
   </head>
-  <body class="safe-padding-bottom">
+  <body class="safe-padding-bottom has-sticky-actions">
     <header class="main-header safe-padding-top">
       <img src="./assets/mount-builder.png" alt="mount builder" class="logo" />
       <nav class="header-nav">
@@ -95,16 +95,21 @@
             <textarea name="notes" id="notes" rows="8"></textarea>
           </div>
         </form>
-        <!-- main action buttons -->
-        <div class="button-group">
+        <!-- main action buttons (inline for larger screens) -->
+        <div class="button-group inline-actions">
           <button type="button" class="input-btn save-btn">Save Sermon</button>
           <button type="button" class="input-btn clear-btn">Clear</button>
-          <button type="button" class="input-btn export-btn">
-            Export Sermon
-          </button>
+          <button type="button" class="input-btn export-btn">Export Sermon</button>
         </div>
       </div>
     </main>
+
+    <!-- sticky action bar for mobile/smaller screens -->
+    <nav class="sticky-actions">
+      <button type="button" class="input-btn save-btn">Save</button>
+      <button type="button" class="input-btn clear-btn">Clear</button>
+      <button type="button" class="input-btn export-btn">Export</button>
+    </nav>
 
     <nav class="tabbar">
       <a href="library.html" class="tab-item">Library</a>


### PR DESCRIPTION
Add a sticky action bar for Save, Clear, and Export buttons to improve accessibility on smaller screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-31735578-e538-470d-9169-95c5fa42292b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-31735578-e538-470d-9169-95c5fa42292b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

