### PR TITLE
Update ui to nav bar and keep search button

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -57,6 +57,26 @@
   background-color: #b22929;
 }
 
+/* Clean header navbar overrides */
+.header-nav .nav-btn {
+  background: transparent;
+  color: #1c1c1e;
+  border: 1px solid transparent;
+  padding: 0.4rem 0.8rem;
+  border-radius: 8px;
+  font-weight: 500;
+}
+
+.header-nav .nav-btn:hover {
+  background: #f5f5f7;
+  color: #1c1c1e;
+}
+
+.header-nav .nav-btn.active {
+  background: #cc3333;
+  color: #ffffff;
+}
+
 /* Make header nav more compact on small screens */
 @media (max-width: 767px) {
   .header-nav {
@@ -275,6 +295,11 @@ textarea:focus {
 textarea {
   resize: vertical;
   min-height: 120px;
+}
+
+/* Hide inline Search verse button in the form */
+.input-with-button .search-btn {
+  display: none !important;
 }
 
 #notes {


### PR DESCRIPTION
Refactor header navigation buttons into a clean, link-style navbar and hide the inline 'Search verse' button to update the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb1a18ec-5087-4f0a-867f-1ae6f779bd61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fb1a18ec-5087-4f0a-867f-1ae6f779bd61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

